### PR TITLE
Introducing an abstraction to efficiently reschedule

### DIFF
--- a/scheduler/src/main/java/dev/gkblt/sdr/scheduler/components/HierarchicalTimerWheel.java
+++ b/scheduler/src/main/java/dev/gkblt/sdr/scheduler/components/HierarchicalTimerWheel.java
@@ -4,7 +4,6 @@ import dev.gkblt.sdr.scheduler.model.Job;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -12,122 +11,38 @@ import java.util.function.Consumer;
 
 public class HierarchicalTimerWheel {
 
-    @Autowired
-    private ITimeProvider time;
+    private final ITimeProvider time;
     private final ExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     private final ArrayList<Consumer<List<Job>>> callbackFunctions;
-    private final int granularity;
-    private final int levelSize;
-    private final long maxRecurrence;
+    final static long MAX_RECURRENCE = 32068200000L;
 
-    private long startTimestamp;
-    LinkedList<Job>[][] entries;
-    protected final int[] currentIndexes;
-    /**
-     *
-     * @param granularity the size of the bucket of the lowest level, in milliseconds
-     * @param levelSize how many buckets each level contains
-     * @param levels how many levels there exists
-     */
-    public HierarchicalTimerWheel(int granularity, int levelSize, int levels) {
-        this.granularity = granularity;
-        this.levelSize = levelSize;
-
-        this.entries = new LinkedList[levels+1][levelSize];
-        long maxRecurrence = 0;
-        for (int l=0;l<=levels;l++) {
-            for (int i=0;i<levelSize;i++) {
-                this.entries[l][i] = new LinkedList<Job>();
-            }
-            if (l < levels) {
-                maxRecurrence += (long) Math.pow(levelSize, l+1);
-            }
-        }
-
-        this.maxRecurrence = maxRecurrence;
-        this.currentIndexes = new int[levels+1];
-
-        this.callbackFunctions = new ArrayList<>();
-
-
-    }
-
-    public long getMaxRecurrence() {
-        return this.maxRecurrence;
-    }
-
-    public HierarchicalTimerWheel(int granularity, int levelSize) {
-        this(granularity, levelSize, 4);
-    }
-
-    /**
-     * The default parameterless constructor will generate a wheel
-     * of 4 levels; the first one contains the immediate minute in 75 seconds
-     * the second one contains the 75^2 seconds, in 75 buckets
-     * and so on.
-     * 75^4/60/60/24 is slightly more than 366 days
-     * Any future scheduling beyond 366 days won't be possible.
-     * That is, recurrence > 366 days won't be supported.
-     *
-     */
-    public HierarchicalTimerWheel() {
-        this(1000,75);
-    }
+    private HierarchicalTimerWheelSlice primary;
+    private HierarchicalTimerWheelSlice secondary;
 
     @Autowired
-    protected void setTime(ITimeProvider timeProvider) {
-        this.time = timeProvider;
-        this.startTimestamp = this.time.now();
-    }
-
-    private LinkedList<Job> locate(long time) {
-
-        int l = 0;
-        long levelStart = 0;
-        long levelRange = levelSize;
-        long levelEnd = levelStart + levelRange;
-        while(time >= levelEnd) {
-            l++;
-            levelStart = levelEnd;
-            levelRange = levelSize * levelRange;
-            levelEnd = levelStart + levelRange;
-        }
-        if (l >= this.currentIndexes.length) {
-            return null;
-        }
-        int idxIntoLevel = (int)((time - levelStart) / (levelRange/levelSize));
-        return entries[l][idxIntoLevel];
+    public HierarchicalTimerWheel(ITimeProvider time) {
+        this.callbackFunctions = new ArrayList<>();
+        this.time = time;
+        long startTime = time.now();
+        this.primary = new HierarchicalTimerWheelSlice(startTime);
+        this.secondary = new HierarchicalTimerWheelSlice(this.primary.getStartTimestamp() + MAX_RECURRENCE);
     }
 
     public boolean remove(Job job) {
-        if (job.nextSchedule() < startTimestamp) {
-            return false;
-        }
-        long nextDue = (job.nextSchedule() - startTimestamp) / granularity;
-        LinkedList<Job> jobSlot = locate(nextDue);
-
-        return jobSlot != null && jobSlot.remove(job);
+        return primary.remove(job);
     }
 
     public boolean add(Job job) {
-        if (job.nextSchedule() < startTimestamp || job.nextSchedule() >= startTimestamp + maxRecurrence) {
+        if (job.nextSchedule() < primary.getStartTimestamp() ) {
             return false;
         }
-        if (job.recurrence().orElse(0L) > maxRecurrence) {
+        if (job.recurrence().orElse(0L) >= MAX_RECURRENCE) {
             return false;
         }
-        return relaxedAdd(job);
-    }
-
-    private boolean relaxedAdd(Job job) {
-        long nextDue = (job.nextSchedule() - startTimestamp) / granularity;
-        LinkedList<Job> jobSlot = locate(nextDue);
-        if (jobSlot == null) {
-            return false;
+        if (job.nextSchedule() < secondary.getStartTimestamp()) {
+            return primary.add(job);
         }
-        jobSlot.add(job);
-        return true;
-
+        return secondary.add(job);
     }
 
     public void registerCallback(Consumer<List<Job>> callbackFunction) {
@@ -146,57 +61,14 @@ public class HierarchicalTimerWheel {
     }
 
     List<Job> jobsDue() {
-        consolidateJobs(0);
-        List<Job> due = (List<Job>) entries[0][currentIndexes[0]].clone();
-        entries[0][currentIndexes[0]].clear();
-        currentIndexes[0]++;
-        return due;
+        List<Job> jobs = primary.jobsDue();
+        if (jobs == null) {
+            assert(time.now() >= secondary.getStartTimestamp());
+            this.primary = this.secondary;
+            this.secondary = new HierarchicalTimerWheelSlice(this.primary.getStartTimestamp() + MAX_RECURRENCE);
+            jobs = primary.jobsDue();
+        }
+        return jobs;
     }
 
-    protected long levelBase(int level) {
-        int l = 0;
-        long levelStart = startTimestamp;
-        long bucketWidth = granularity;
-        while(l < level) {
-            levelStart += bucketWidth*levelSize;
-            bucketWidth *= granularity;
-            l++;
-        }
-        return levelStart;
-    }
-    /**
-     * moves jobs from one upper level to the current level, recursively
-     * @param level
-     */
-    private void consolidateJobs(int level) {
-        if (currentIndexes[level] < levelSize) {
-            return;
-        }
-        if (level == currentIndexes.length - 1) {
-            return;
-        }
-        if (level == currentIndexes.length - 2) {
-            // The last level is buffer for future scheduling. start time shall be reset at level n-1, at which time the last level's jobs
-            // will be distributed to the prior levels.
-            // move startTime ahead
-            startTimestamp += maxRecurrence;
-        }
-         if (currentIndexes[level+1] < levelSize) {
-            LinkedList<Job> nextLevelJobs = entries[level+1][currentIndexes[level+1]];
-            long rangeStart = levelBase(level+1);
-
-            for (Job job : nextLevelJobs) {
-               int indexIntoCurrentLevel = (int)(((job.nextSchedule() - rangeStart) % Math.pow(granularity, level+2)) / Math.pow(granularity, level+1));
-               entries[level][indexIntoCurrentLevel].add(job);
-            }
-
-            entries[level+1][currentIndexes[level+1]].clear();
-            if (level != currentIndexes.length - 1)
-                currentIndexes[level+1]++;
-            currentIndexes[level] = 0;
-        } else {
-             consolidateJobs(level+1);
-             consolidateJobs(level);
-         }
-    }
 }

--- a/scheduler/src/main/java/dev/gkblt/sdr/scheduler/components/HierarchicalTimerWheelSlice.java
+++ b/scheduler/src/main/java/dev/gkblt/sdr/scheduler/components/HierarchicalTimerWheelSlice.java
@@ -1,0 +1,165 @@
+package dev.gkblt.sdr.scheduler.components;
+
+import dev.gkblt.sdr.scheduler.model.Job;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+
+public class HierarchicalTimerWheelSlice {
+    private final int granularity;
+    private final int levelSize;
+    private final long maxRecurrence;
+
+    private final long startTimestamp;
+    LinkedList<Job>[][] entries;
+    protected final int[] currentIndexes;
+    /**
+     *
+     * @param granularity the size of the bucket of the lowest level, in milliseconds
+     * @param levelSize how many buckets each level contains
+     * @param levels how many levels there exists
+     */
+    public HierarchicalTimerWheelSlice(long startTimestamp, int granularity, int levelSize, int levels) {
+        this.startTimestamp = startTimestamp;
+        this.granularity = granularity;
+        this.levelSize = levelSize;
+
+        this.entries = new LinkedList[levels][levelSize];
+        long maxRecurrence = 0;
+        for (int l=0;l<levels;l++) {
+            for (int i=0;i<levelSize;i++) {
+                this.entries[l][i] = new LinkedList<Job>();
+            }
+            maxRecurrence += granularity * (long) Math.pow(levelSize, l+1);
+        }
+
+        this.maxRecurrence = maxRecurrence;
+        this.currentIndexes = new int[levels];
+    }
+
+
+    public HierarchicalTimerWheelSlice(long startTimestamp, int granularity, int levelSize) {
+        this(startTimestamp, granularity, levelSize, 4);
+    }
+
+    /**
+     * The default parameterless constructor will generate a wheel
+     * of 4 levels; the first one contains the immediate minute in 75 seconds
+     * the second one contains the 75^2 seconds, in 75 buckets
+     * and so on.
+     * 75^4/60/60/24 is slightly more than 366 days
+     * Any future scheduling beyond 366 days won't be possible.
+     * That is, recurrence > 366 days won't be supported.
+     *
+     */
+    public HierarchicalTimerWheelSlice(long startTimestamp) {
+        this(startTimestamp, 1000,75);
+    }
+
+    public long getMaxRecurrence() {
+        return this.maxRecurrence;
+    }
+
+    public long getStartTimestamp() {
+        return this.startTimestamp;
+    }
+
+    private LinkedList<Job> locate(long time) {
+
+        int l = 0;
+        long levelStart = 0;
+        long levelRange = levelSize;
+        long levelEnd = levelStart + levelRange;
+        while(time >= levelEnd) {
+            l++;
+            levelStart = levelEnd;
+            levelRange = levelSize * levelRange;
+            levelEnd = levelStart + levelRange;
+        }
+        if (l >= this.currentIndexes.length) {
+            return null;
+        }
+        int idxIntoLevel = (int)((time - levelStart) / (levelRange/levelSize));
+        return entries[l][idxIntoLevel];
+    }
+
+    public boolean remove(Job job) {
+        if (job.nextSchedule() < startTimestamp || job.nextSchedule() >= startTimestamp + maxRecurrence) {
+            return false;
+        }
+        long nextDue = (job.nextSchedule() - startTimestamp) / granularity;
+        LinkedList<Job> jobSlot = locate(nextDue);
+
+        return jobSlot != null && jobSlot.remove(job);
+    }
+
+    public boolean add(Job job) {
+        if (job.nextSchedule() < startTimestamp || job.nextSchedule() >= startTimestamp + maxRecurrence) {
+            return false;
+        }
+        long nextDue = (job.nextSchedule() - startTimestamp) / granularity;
+        LinkedList<Job> jobSlot = locate(nextDue);
+        if (jobSlot == null) {
+            return false;
+        }
+        jobSlot.add(job);
+        return true;
+    }
+
+    protected List<Job> jobsDue() {
+        if (consolidateJobs(0)) {
+            List<Job> due = (List<Job>) entries[0][currentIndexes[0]].clone();
+            entries[0][currentIndexes[0]].clear();
+            currentIndexes[0]++;
+            return due;
+        } else {
+            return null;
+        }
+    }
+
+    protected long levelBase(int level) {
+        int l = 0;
+        long levelStart = startTimestamp;
+        long bucketWidth = granularity;
+        while(l < level) {
+            levelStart += bucketWidth*levelSize;
+            bucketWidth *= granularity;
+            l++;
+        }
+        return levelStart;
+    }
+    /**
+     * moves jobs from one upper level to the current level, recursively
+     * @param level
+     */
+    private boolean consolidateJobs(int level) {
+        if (level == currentIndexes.length - 1) {
+            return currentIndexes[level] < levelSize;
+        }
+        if (currentIndexes[level] < levelSize) {
+            return true;
+        }
+        if (currentIndexes[level+1] < levelSize) {
+            LinkedList<Job> nextLevelJobs = entries[level + 1][currentIndexes[level + 1]];
+            long rangeStart = levelBase(level + 1);
+
+            for (Job job : nextLevelJobs) {
+                int indexIntoCurrentLevel = (int) (((job.nextSchedule() - rangeStart) % Math.pow(granularity, level + 2)) / Math.pow(granularity, level + 1));
+                entries[level][indexIntoCurrentLevel].add(job);
+            }
+
+            entries[level + 1][currentIndexes[level + 1]].clear();
+            if (level != currentIndexes.length - 1)
+                currentIndexes[level + 1]++;
+            currentIndexes[level] = 0;
+            return true;
+        } else {
+            return consolidateJobs(level + 1) && consolidateJobs(level);
+        }
+    }
+}

--- a/scheduler/src/test/java/dev/gkblt/sdr/scheduler/components/HierarchicalTimerWheelSliceTests.java
+++ b/scheduler/src/test/java/dev/gkblt/sdr/scheduler/components/HierarchicalTimerWheelSliceTests.java
@@ -1,0 +1,150 @@
+package dev.gkblt.sdr.scheduler.components;
+
+import dev.gkblt.sdr.scheduler.model.Job;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HierarchicalTimerWheelSliceTests {
+    private Job newJob(long schedule) {
+        return new Job(4, 1, schedule, Optional.empty());
+    }
+
+    @Test
+    void add_removeTests() {
+        HierarchicalTimerWheelSlice wheel = new HierarchicalTimerWheelSlice(0, 1, 10, 4);
+        wheel.add(newJob(3L));
+        assert (wheel.entries[0][3].size() == 1);
+        wheel.remove(newJob(3L));
+        assert (wheel.entries[0][3].size() == 0);
+
+        wheel.add(newJob(0L));
+        assert (wheel.entries[0][0].size() == 1);
+        wheel.remove(newJob(0L));
+        assert (wheel.entries[0][0].size() == 0);
+
+        wheel.add(newJob(10L));
+        assert (wheel.entries[1][0].size() == 1);
+        wheel.add(newJob(11L));
+        assert (wheel.entries[1][0].size() == 2);
+        wheel.remove(newJob(10L));
+        assert (wheel.entries[1][0].size() == 1);
+        wheel.remove(newJob(11L));
+        assert (wheel.entries[1][0].size() == 0);
+
+        wheel.add(newJob(90L));
+        assert (wheel.entries[1][8].size() == 1);
+        wheel.remove(newJob(90L));
+        assert (wheel.entries[1][8].size() == 0);
+
+        wheel.add(newJob(105L));
+        assert (wheel.entries[1][9].size() == 1);
+        wheel.remove(newJob(105L));
+        assert (wheel.entries[1][9].size() == 0);
+
+        wheel.add(newJob(110L));
+        assert (wheel.entries[2][0].size() == 1);
+        wheel.remove(newJob(110L));
+        assert (wheel.entries[2][0].size() == 0);
+
+        wheel.add(newJob(1110L));
+        assert (wheel.entries[3][0].size() == 1);
+        wheel.remove(newJob(1110L));
+        assert (wheel.entries[3][0].size() == 0);
+
+        wheel.add(newJob(11109L));
+        assert (wheel.entries[3][9].size() == 1);
+        wheel.remove(newJob(11109L));
+        assert (wheel.entries[3][9].size() == 0);
+
+        // 11110 is greater than the max that can be scheduled. add() should handle it properly
+        assert (!wheel.add(newJob(11110L)));
+
+        // Removing a non-existing Job
+        assert (!wheel.remove(newJob(123L)));
+    }
+
+    @Test
+    void granularityTest() {
+        HierarchicalTimerWheelSlice wheel = new HierarchicalTimerWheelSlice(0,10, 10, 4);
+        wheel.add(newJob(3L));
+        assert (wheel.entries[0][0].size() == 1);
+        wheel.remove(newJob(3L));
+        assert (wheel.entries[0][0].size() == 0);
+
+        wheel.add(newJob(30L));
+        assert (wheel.entries[0][3].size() == 1);
+        wheel.remove(newJob(30L));
+        assert (wheel.entries[0][3].size() == 0);
+    }
+
+    @Test
+    void startTimestampTest() {
+        HierarchicalTimerWheelSlice wheel = new HierarchicalTimerWheelSlice(1000, 10, 10, 4);
+
+        wheel.add(newJob(1003L));
+        assert (wheel.entries[0][0].size() == 1);
+        wheel.remove(newJob(1003L));
+        assert (wheel.entries[0][0].size() == 0);
+
+        wheel.add(newJob(1030L));
+        assert (wheel.entries[0][3].size() == 1);
+        wheel.remove(newJob(1030L));
+        assert (wheel.entries[0][3].size() == 0);
+
+        // 10 is less than startTimestamp. HTW.add should gracefully handle it.
+        assert (!wheel.add(newJob(10L)));
+        assert (!wheel.remove(newJob(10L)));
+    }
+
+    @Test
+    void getMaxRecurrenceTest() {
+        HierarchicalTimerWheelSlice wheel = new HierarchicalTimerWheelSlice(0,1000, 75, 4);
+        // 75+75*75+75*75*75+75*75*75*75 = 32068200
+        // since granularity is 1000, the maxRecurrence must match
+        // 32068200000
+        assertEquals(32068200000L, wheel.getMaxRecurrence()) ;
+    }
+    @Test
+    void jobsDueTest() {
+        HierarchicalTimerWheelSlice wheel = new HierarchicalTimerWheelSlice(0,10, 10, 4);
+
+
+        // insert one job with each timestamp. Since each bucket's granularity is 10 units, it'll be inserting 10 jobs to each bucket.
+        // getMaxRecurrence
+        long jobsCount = wheel.getMaxRecurrence();
+
+        for (int i = 0; i < jobsCount; i++) {
+            wheel.add(newJob(i));
+        }
+
+        int i = 0;
+        for (int j = 0; j < jobsCount / 10; j++) {
+            List<Job> jobs = wheel.jobsDue();
+            assertEquals (10, jobs.size());
+            while(!jobs.isEmpty())  {
+                Job job = jobs.remove(0);
+                assertEquals(i, job.nextSchedule());
+                i++;
+            }
+        }
+        assertEquals(jobsCount, i);
+    }
+
+
+    @Test
+    void levelBaseTest() {
+        HierarchicalTimerWheelSlice wheel = new HierarchicalTimerWheelSlice(300, 10, 10, 4);
+
+        long expectedStart = 300;
+        for (int l=0;l<4;l++) {
+            long actual = wheel.levelBase(l);
+            assertEquals(expectedStart, actual, String.format("level=%d", l));
+            expectedStart += Math.pow(10 , (l + 2));
+        }
+
+    }
+}

--- a/scheduler/src/test/java/dev/gkblt/sdr/scheduler/components/HierarchicalTimerWheelTests.java
+++ b/scheduler/src/test/java/dev/gkblt/sdr/scheduler/components/HierarchicalTimerWheelTests.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 class HierarchicalTimerWheelTests {
@@ -19,134 +20,30 @@ class HierarchicalTimerWheelTests {
     }
 
     @Test
-    void add_removeTests() {
-        HierarchicalTimerWheel wheel = new HierarchicalTimerWheel(1, 10, 4);
-        wheel.add(newJob(3L));
-        assert (wheel.entries[0][3].size() == 1);
-        wheel.remove(newJob(3L));
-        assert (wheel.entries[0][3].size() == 0);
-
-        wheel.add(newJob(0L));
-        assert (wheel.entries[0][0].size() == 1);
-        wheel.remove(newJob(0L));
-        assert (wheel.entries[0][0].size() == 0);
-
-        wheel.add(newJob(10L));
-        assert (wheel.entries[1][0].size() == 1);
-        wheel.add(newJob(11L));
-        assert (wheel.entries[1][0].size() == 2);
-        wheel.remove(newJob(10L));
-        assert (wheel.entries[1][0].size() == 1);
-        wheel.remove(newJob(11L));
-        assert (wheel.entries[1][0].size() == 0);
-
-        wheel.add(newJob(90L));
-        assert (wheel.entries[1][8].size() == 1);
-        wheel.remove(newJob(90L));
-        assert (wheel.entries[1][8].size() == 0);
-
-        wheel.add(newJob(105L));
-        assert (wheel.entries[1][9].size() == 1);
-        wheel.remove(newJob(105L));
-        assert (wheel.entries[1][9].size() == 0);
-
-        wheel.add(newJob(110L));
-        assert (wheel.entries[2][0].size() == 1);
-        wheel.remove(newJob(110L));
-        assert (wheel.entries[2][0].size() == 0);
-
-        wheel.add(newJob(1110L));
-        assert (wheel.entries[3][0].size() == 1);
-        wheel.remove(newJob(1110L));
-        assert (wheel.entries[3][0].size() == 0);
-
-        wheel.add(newJob(11109L));
-        assert (wheel.entries[3][9].size() == 1);
-        wheel.remove(newJob(11109L));
-        assert (wheel.entries[3][9].size() == 0);
-
-        // 11110 is greater than the max that can be scheduled. add() should handle it properly
-        assert (!wheel.add(newJob(11110L)));
-
-        // Removing a non-existing Job
-        assert (!wheel.remove(newJob(123L)));
-    }
-
-    @Test
-    void granularityTest() {
-        HierarchicalTimerWheel wheel = new HierarchicalTimerWheel(10, 10, 4);
-        wheel.add(newJob(3L));
-        assert (wheel.entries[0][0].size() == 1);
-        wheel.remove(newJob(3L));
-        assert (wheel.entries[0][0].size() == 0);
-
-        wheel.add(newJob(30L));
-        assert (wheel.entries[0][3].size() == 1);
-        wheel.remove(newJob(30L));
-        assert (wheel.entries[0][3].size() == 0);
-    }
-
-    @Test
-    void startTimestampTest() {
+    void jobsDueAlternatesPrimaryAndSecondary() {
         TestTimeProvider time = new TestTimeProvider(0);
-        time.advance(1000);
-        HierarchicalTimerWheel wheel = new HierarchicalTimerWheel(10, 10, 4);
-        wheel.setTime(time);
-        wheel.add(newJob(1003L));
-        assert (wheel.entries[0][0].size() == 1);
-        wheel.remove(newJob(1003L));
-        assert (wheel.entries[0][0].size() == 0);
+        HierarchicalTimerWheel wheel = new HierarchicalTimerWheel(time);
 
-        wheel.add(newJob(1030L));
-        assert (wheel.entries[0][3].size() == 1);
-        wheel.remove(newJob(1030L));
-        assert (wheel.entries[0][3].size() == 0);
-
-        // 10 is less than startTimestamp. HTW.add should gracefully handle it.
-        assert (!wheel.add(newJob(10L)));
-        assert (!wheel.remove(newJob(10L)));
-    }
-
-    @Test
-    void getMaxRecurrenceTest() {
-        HierarchicalTimerWheel wheel = new HierarchicalTimerWheel(1000, 75, 4);
-        // 75+75*75+75*75*75+75*75*75*75 = 32068200
-        assertEquals(32068200, wheel.getMaxRecurrence()) ;
-    }
-    @Test
-    void jobsDueTest() {
-        HierarchicalTimerWheel wheel = new HierarchicalTimerWheel(10, 10, 4);
-        for (int i = 0; i < wheel.getMaxRecurrence(); i++) {
-            wheel.add(newJob(i));
-        }
-
-        int i = 0;
-        for (int j = 0; j < wheel.getMaxRecurrence() / 10; j++) {
+        Job theJob = newJob(100);
+        wheel.add(theJob);
+        for (int year = 0; year < 4; year++) {
+            time.advance(1000);
             List<Job> jobs = wheel.jobsDue();
-            assertEquals (10, jobs.size());
-            while(!jobs.isEmpty())  {
-                Job job = jobs.remove(0);
-                assertEquals(i, job.nextSchedule());
-                i++;
+            assertEquals(1, jobs.size());
+            assertEquals(theJob, jobs.get(0));
+            theJob = newJob(theJob.nextSchedule() + HierarchicalTimerWheel.MAX_RECURRENCE);
+            wheel.add(theJob);
+
+            while (time.now() % HierarchicalTimerWheel.MAX_RECURRENCE != 0) {
+                time.advance(1000);
+                jobs = wheel.jobsDue();
+                assertNotNull(jobs);
+                assertEquals(0, jobs.size());
             }
-        }
-    }
 
-    @Test
-    void levelBaseTest() {
-        TestTimeProvider time = new TestTimeProvider(0);
-        HierarchicalTimerWheel wheel = new HierarchicalTimerWheel(10, 10, 4);
-        int start = 300;
-        time.advance(start);
-        wheel.setTime(time);
-
-        long expectedStart = start;
-        for (int l=0;l<4;l++) {
-            long actual = wheel.levelBase(l);
-            assertEquals(expectedStart, actual, String.format("level=%d", l));
-            expectedStart += Math.pow(10 , (l + 2));
         }
 
     }
+
 }
 


### PR DESCRIPTION
Much of the functionality of HTW is moved to a new type - HierarchicalTimerWheelSlice.
The new type is capable of adding and removing jobs to its layered circular buffers. It has a fixed epoch. and once all the jobs are consumed it signals the caller of jobsDue by returning null, indicating that the entire wheel is drained.
HierarchicalTimerWheel employs two HTWSlices, primary and secondary. primary is current, and secondary is used to store the schedules in the next time window. HTW.jobsDue swaps primary and secondary if primary drains and creates a new secondary.